### PR TITLE
ヘッダーのリンク修正

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -128,3 +128,6 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 LOGIN_REDIRECT_URL = "/daily_reports/"
 LOGOUT_REDIRECT_URL = "/login/"
+
+# login_requiredでの遷移先を/login/に設定
+LOGIN_URL = "/login/"

--- a/config/urls.py
+++ b/config/urls.py
@@ -18,11 +18,10 @@ from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.urls import include, path
 
-from employees.views import home
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("", home, name="home"),
+    # path("", home, name="home"),
     path("employees/", include("employees.urls")),
     path("daily_reports/", include("daily_reports.urls")),
     path(

--- a/employees/views.py
+++ b/employees/views.py
@@ -3,15 +3,17 @@ from django.contrib.auth.models import User
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.decorators import method_decorator
 from django.views.generic import ListView
+from django.contrib.auth.decorators import login_required
 
 from .forms import EmployeeUserForm
 from .models import Employee
 
 
-def home(request):
-    return render(request, "home.html")
+# def home(request):
+#     return render(request, "home.html")
 
 
+@login_required
 @staff_member_required
 def employee_new(request):
     if request.method == "POST":
@@ -24,6 +26,7 @@ def employee_new(request):
     return render(request, "employees/employee_form.html", {"form": form})
 
 
+@method_decorator(login_required, name="dispatch")
 @method_decorator(staff_member_required, name="dispatch")
 class EmployeeListView(ListView):
     model = Employee
@@ -32,17 +35,19 @@ class EmployeeListView(ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["user"] = User.objects.select_related("user").values("is_staff")
+        context["user"] = self.request.user
         return context
 
 
 # TODO Email, Username, Passwordを変更可能にする。
+@login_required
 @staff_member_required
 def employee_edit(request, pk):
     employee = get_object_or_404(Employee, pk=pk)
     return render(request, "employees/employee_edit.html", {"employee": employee})
 
 
+@login_required
 @staff_member_required
 def employee_update(request, pk):
     employee = get_object_or_404(Employee, pk=pk)
@@ -54,6 +59,7 @@ def employee_update(request, pk):
     return redirect("employee_edit", pk=pk)
 
 
+@login_required
 @staff_member_required
 def employee_delete_confirm(request, pk):
     employee = get_object_or_404(Employee, pk=pk)
@@ -62,6 +68,7 @@ def employee_delete_confirm(request, pk):
     )
 
 
+@login_required
 @staff_member_required
 def employee_delete(request, pk):
     employee = get_object_or_404(Employee, pk=pk)

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,7 @@
     {% comment %} ナビゲーションバー {% endcomment %}
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
       <div class="container">
-        <a class="navbar-brand" href="{% url 'home' %}">日報管理システム</a>
+        <a class="navbar-brand" href="{% url 'daily_report_index' %}">日報管理システム</a>
         <button
           class="navbar-toggler"
           type="button"
@@ -24,13 +24,18 @@
             <li class="nav-item">
               <a class="nav-link">{{ user.username }}</a>
             </li>
-            {% if user.is_staff %}
+              {% if user.is_staff %}
+              <li class="nav-item">
+                <a class="nav-link" href="{% url 'employee_index' %}"
+                 >従業員管理</a
+                >
+              </li>
+              {% endif %}
             <li class="nav-item">
-              <a class="nav-link" href="{% url 'employee_index' %}"
-                >従業員管理</a
+              <a class="nav-link" href="{% url 'daily_report_index' %}"
+                >日報管理</a
               >
             </li>
-            {% endif %}
             <li class="nav-item">
               <a class="nav-link" href="{% url 'logout' %}">ログアウト</a>
             </li>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,12 +1,20 @@
+{% extends "base.html" %}
+
+{% block title %}トップページ{% endblock title %}
+
+{% block content %}
+
 {% if user.is_authenticated %}
 <h1>{{ user.username }}さん、ようこそ！</h1>
 <ul>
   {% if user.is_staff %}
-  <li><a href="{% url 'daily_report_index' %}">日報一覧</a></li>
+  <li><a href="{% url 'employee_index' %}">従業員一覧</a></li>
   {% endif %}
+  <li><a href="{% url 'daily_report_index' %}">日報一覧</a></li>
   <li><a href="{% url 'logout' %}">ログアウト</a></li>
 </ul>
 {% else %}
 <h1>ログインしてください</h1>
 <a href="{% url 'login' %}">ログイン画面へ</a>
 {% endif %}
+{% endblock %}


### PR DESCRIPTION
https://github.com/akiya-n2501/daily_report_system/issues/11

やったこと：
・homeのurlを削除
・ヘッダーから日報一覧に飛べるようにリンクを調整
・従業員関連のビューにlogin_requiredを設定
・login_requiredの遷移先をlogin画面に変更

レビューよろしくお願いします。

is_staffである時
![image](https://github.com/user-attachments/assets/3a4beb73-2510-4875-aada-6861b4c0f4fe)

is_staffでない時
![image](https://github.com/user-attachments/assets/f01582fd-99c0-416e-a0e1-8fd48a500713)
